### PR TITLE
Comprehensive network interface support: DHCP on all the things!

### DIFF
--- a/microkernel.ks
+++ b/microkernel.ks
@@ -6,7 +6,8 @@ timezone US/Eastern
 auth --useshadow --enablemd5
 selinux --permissive
 bootloader --timeout=1 --append="acpi=force"
-network --bootproto=dhcp --device=eth0 --onboot=on
+# we don't want network auto-configured -- udev does that on boot!
+# network --bootproto=dhcp --device=eth0 --onboot=on
 services --enabled=network
 
 # Uncomment the next line
@@ -118,3 +119,6 @@ yum -y erase binutils
 #rpm -e gnupg2 gpgme pygpgme yum rpm-build-libs rpm-python
 #rm -rf /var/lib/rpm
 %end
+
+# Network configuration
+%include mk-network.ks

--- a/mk-network.ks
+++ b/mk-network.ks
@@ -1,0 +1,40 @@
+%post
+# systemd is notified at priority 99, but all other configuration of
+# the network should have happened before this is triggered.  The final
+# result *should* be that this runs and creates a network configuration
+# file before systemd checks to act on the network configuration for
+# the newly discovered interface...
+#
+# By restarting the networking target we help ensure that we do, in fact,
+# trigger the appropriate network setup.
+cat > /etc/udev/rules.d/97-write-network-configuration.rules <<'EOF'
+ACTION=="add", SUBSYSTEM=="net", RUN+="/usr/local/bin/new-net-device"
+EOF
+
+cat > /usr/local/bin/new-net-device <<'EOF'
+#!/bin/bash
+# we don't want to mess with loopback, thanks
+test x"${INTERFACE}" = x"lo" && exit 0
+
+# ensure that any other interface is configured via DHCP...
+if ! test -f /etc/sysconfig/network-scripts/ifcfg-"${INTERFACE}"; then
+    cat > /etc/sysconfig/network-scripts/ifcfg-"${INTERFACE}" <<EOT
+DEVICE=${INTERFACE}
+ONBOOT=on
+# Both of the settings after dhcp are essential -- or else
+# we "fail" if DHCP is not available on the interface, and
+# consequently fail the network service, and badness follows
+BOOTPROTO=dhcp
+PERSISTENT_DHCLIENT=YES
+IPV4_FAILURE_FATAL=NO
+EOT
+fi
+
+# ...and bring it up, by asking systemd to do that for us.
+# --no-block is important: otherwise we can time out waiting for the
+# restart to complete, because DHCP timeouts take ages.
+/bin/systemctl --no-block restart network.service
+EOF
+
+chmod +x /usr/local/bin/new-net-device
+%end


### PR DESCRIPTION
This implements DHCP configuration for all network interfaces.  Literally all
of them, in fact: anything other than the loopback interface should
automatically be:

A) added to `/etc/sysconfig/network-scripts/ifcfg-*`.
B) configured for DHCP.
C) configured not to fail if a DHCP offer is not received, but to
   keep trying until one finally arrives on that interface.
D) brought up with the `network.service` systemd unit.

This is fully automatic -- no user configuration is supported, and it is
fully driven out of udev device discovery.

This also means that it should work with, eg, hotplug network interfaces, USB
devices that show up late, layered or lazy network interfaces (if anyone _ever_
implements one of them, though VPN seems ... possible, if crazy), etc.

Signed-off-by: Daniel Pittman daniel@rimspace.net
