### PR TITLE
Migrate to a systemd timer rather than a Ruby loop

### DIFF
--- a/bin/mk
+++ b/bin/mk
@@ -33,16 +33,6 @@ EOT
   exit outcome
 end
 
-# @todo lutter 2013-08-18: What we do for the daemon is mostly fine for
-# systemd, but for SysV we'd have to do quite a bit more to make running
-# the daemon robust.
-if ARGV[0] == "--daemon"
-  daemon = true
-  ARGV.shift
-else
-  daemon = false
-end
-
 # Figure out, and dispatch, to our command.
 command = ARGV.shift or usage(false, 'No command was supplied')
 MK::Script.respond_to?(command) or usage(false, "Unknown command #{command.inspect}")
@@ -50,22 +40,7 @@ MK::Script.respond_to?(command) or usage(false, "Unknown command #{command.inspe
 result = false
 
 begin
-  loop do
-    begin
-      result = MK::Script.send(command, *ARGV)
-    rescue MK::Server::ConnectionFailedError => e
-      if daemon
-        # In daemon mode, we simply want to continue, since the best
-        # we can hope for is that the failure is transient
-        puts e.to_s
-      else
-        raise e
-      end
-    end
-    break unless daemon
-    sleep 15
-    puts "\nRunning at #{Time.now}"
-  end
+  result = MK::Script.send(command, *ARGV)
 rescue Exception => e
   # This would otherwise catch SystemExit, which we kind of don't want to do.
   usage(false, "error running #{command}: #{e}")

--- a/build-livecd
+++ b/build-livecd
@@ -25,28 +25,19 @@ cp $TOP_DIR/pkg/razor-mk-agent-${VERSION}.gem \$INSTALL_ROOT/var/tmp
 gem install -l --no-ri --no-rdoc /var/tmp/razor-mk-agent-${VERSION}.gem
 
 cat > /etc/systemd/system/mk.service <<EOUNIT
-[Unit]
-Description=Microkernel agent
-After=network.target syslog.target nss-lookup.target
+$(< etc/mk.service)
+EOUNIT
 
-[Service]
-Type=simple
-WorkingDirectory=/var/lib/mk
-StandardInput=null
-StandardOutput=syslog
-StandardError=inherit
-SyslogIdentifier=microkernel
-ExecStart=/usr/local/bin/mk --daemon register
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
+cat > /etc/systemd/system/mk.timer <<EOUNIT
+$(< etc/mk.timer)
 EOUNIT
 
 mkdir /var/lib/mk
-systemctl enable mk.service
+systemctl enable mk.timer
 
 mkdir /usr/lib/razor
+
+# enable the `reboot` command from the Razor server
 ln -sf /sbin/reboot /usr/lib/razor/reboot
 %end
 EOF

--- a/etc/mk.service
+++ b/etc/mk.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Razor Microkernel agent
+After=network.target syslog.target nss-lookup.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/var/lib/mk
+StandardInput=null
+StandardOutput=syslog
+StandardError=inherit
+SyslogIdentifier=microkernel
+ExecStart=/usr/local/bin/mk register
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/mk.timer
+++ b/etc/mk.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Razor Microkernel Agent trigger
+After=network.target syslog.target nss-lookup.target
+
+[Timer]
+# Thirty seconds idle time between boot and running the agent the first time
+# seems like a reasonable delay to me.
+OnBootSec=30
+# ...and every fifteen seconds after we *finished* the last command.
+OnUnitInactiveSec=15
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This migrates the Microkernel binary away from a Ruby "daemon" and back to a
model where an external process supervisor triggers each run.  This, in turn,
resolves the robustness problem where network issues can cause it to fail out
and ultimately never restart.

In this model a systemd `mk.timer` unit replaces the Ruby daemon code, and the
`mk.service` unit is a one-shot trigger that runs the script and exits -- good
or bad -- before waiting on being triggered again.

The one feature this lacks is adjusting the timer interval dynamically; it is
technically possible (by editing the timer unit and reloading it), but not
implemented and possibly not entirely desirable.

This should, at least, make the registration (and, presently, command
execution) process as robust as systemd itself, which should be approximately
as robust as the entire Linux stack.

Signed-off-by: Daniel Pittman daniel@rimspace.net
