### PR TITLE
Use sysfs directly to obtain hardware ID MAC address data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'rspec-core', '~> 2.13.0'
   gem 'rspec-expectations', '~> 2.13.0'
   gem 'rspec-mocks', '~> 2.13.0'
+  gem 'fakefs',  '~> 0.4.3'
   gem 'simplecov'
   gem 'fuubar'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     diff-lcs (1.2.4)
     facter (1.7.2)
+    fakefs (0.4.3)
     fuubar (1.1.1)
       rspec (~> 2.0)
       rspec-instafail (~> 0.2.0)
@@ -28,6 +29,7 @@ PLATFORMS
 
 DEPENDENCIES
   facter
+  fakefs
   fuubar
   rspec (~> 2.13.0)
   rspec-core (~> 2.13.0)

--- a/spec/mk/node_spec.rb
+++ b/spec/mk/node_spec.rb
@@ -5,6 +5,9 @@ describe MK::Node do
   subject(:node) { MK::Node.instance }
 
   context "hw_id" do
+    # every test in this block will run with a fresh, fake filesystem
+    include FakeFS::SpecHelpers
+
     # @todo danielp 2013-07-25: the semantics of this situation are unclear to
     # me, but I think that "fail and assume that either the MK reboots, or a
     # network interface eventually shows up when we are restarted" are
@@ -23,19 +26,6 @@ describe MK::Node do
       }.to raise_error RuntimeError, /no network interfaces detected/
     end
 
-    it "should return the mac of the 'first' Ethernet-ish network interface" do
-      # @todo danielp 2013-07-25: Facter defines no particular order for
-      # network interfaces, and the results are coincidentally based on what
-      # `ifconfig` reports, and on the order of values from a hash.  Should we
-      # have a stricter definition, such as 'asciibetical' or something?
-      stub_interfaces(
-        'lo0'   => nil,
-        'wlan0' => 'c8:bc:c8:d8:4f:04',
-        'eth0'  => 'c8:bc:c8:96:67:51')
-
-      node.hw_id.should == 'c8bcc8966751'
-    end
-
     it "should concatenate multiple Ethernet-ish MACs" do
       stub_interfaces(
         'lo0'   => nil,
@@ -43,19 +33,16 @@ describe MK::Node do
         'eth0'  => 'c8:bc:c8:96:67:51',
         'eth1'  => '00:0c:29:82:5e:22')
 
-      node.hw_id.should == 'c8bcc8966751_000c29825e22'
+      node.hw_id.should == 'c8bcc8966751_000c29825e22_c8bcc8d84f04'
     end
 
-    it "should concatenate multiple Ethernet-ish MACs in the order Facter returns them" do
-      # This depends on Ruby 1.9 Hash semantics, "you get out what you put
-      # in", to function.
+    it "should concatenate multiple Ethernet-ish MACs in sorted-by-name order" do
       stub_interfaces(
         'lo0'   => nil,
-        'wlan0' => 'c8:bc:c8:d8:4f:04',
         'eth1'  => 'c8:bc:c8:96:67:51',
         'eth0'  => '00:0c:29:82:5e:22')
 
-      node.hw_id.should == 'c8bcc8966751_000c29825e22'
+      node.hw_id.should == '000c29825e22_c8bcc8966751'
     end
 
     it "should ignore inaccessible MACs on Ethernet-ish interfaces" do
@@ -69,15 +56,12 @@ describe MK::Node do
         'eth1'  => nil,
         'eth0'  => '00:0c:29:82:5e:22')
 
-      node.hw_id.should == '000c29825e22'
+      node.hw_id.should == '000c29825e22_c8bcc8d84f04'
     end
   end
 
   context "facts" do
     let :facts do Facter.to_hash end
-
-    # Ensure consistent hardware ID is available.
-    before :each do stub_interfaces('eth0' => '00:0c:29:82:5e:22') end
 
     it "should return facts as a hash" do
       node.facts.should be_an_instance_of Hash

--- a/spec/mk/script_spec.rb
+++ b/spec/mk/script_spec.rb
@@ -58,8 +58,14 @@ describe "register" do
   end
 
   it "should register with the server" do
+    # We have to force facter to load facts before we fake the filesystem;
+    # sorry this is so ugly.
+    Facter.to_hash
+
+    FakeFS.activate!
     stub_interfaces('eth0' => '00:00:00:00:00:00')
     MK::Script.register
+    FakeFS.deactivate!
 
     last_registration['Content-Type'].should == 'application/json'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,24 +4,41 @@ SimpleCov.start do
   add_filter ".erb"
 end
 
+# Load, but don't immediately use, the fake filesystem magic
+# See https://github.com/defunkt/fakefs for details
+require 'fakefs/safe'
+require 'fakefs/spec_helpers'
+
+
 module StubHelpers
   # Stub Facter to return a fixed set of MAC addresses for interfaces:
   # `stub_interfaces('eth0' => 'aa:bb:cc:dd:ee:ff', 'eth1' => '...')`
   def stub_interfaces(interfaces)
-    Facter::Util::IP.stub(:get_interfaces).and_return(interfaces.keys)
-    Facter::Util::IP.stub(:get_interface_value) do |name, value|
-      case value
-      when 'macaddress'
-        interfaces.has_key?(name) or
-          raise "facter really just explodes, but we have a nice error message"
-        interfaces[name]
-      when 'ipaddress'  then '127.0.0.1'
-      when 'ipaddress6' then "\n"
-      when 'netmask'    then '255.0.0.0'
-      when 'mtu'        then '16384'
-      when 'network'    then '127.0.0.0'
-      else puts "unsupported interface value #{value.inspect}"
-      end
+    # Facter::Util::IP.stub(:get_interfaces).and_return(interfaces.keys)
+    # Facter::Util::IP.stub(:get_interface_value) do |name, value|
+    #   case value
+    #   when 'macaddress'
+    #     interfaces.has_key?(name) or
+    #       raise "facter really just explodes, but we have a nice error message"
+    #     interfaces[name]
+    #   when 'ipaddress'  then '127.0.0.1'
+    #   when 'ipaddress6' then "\n"
+    #   when 'netmask'    then '255.0.0.0'
+    #   when 'mtu'        then '16384'
+    #   when 'network'    then '127.0.0.0'
+    #   else puts "unsupported interface value #{value.inspect}"
+    #   end
+    # end
+
+    interfaces.each do |name, address|
+      # This isn't the whole tree, so is kinda coupled to the implementation.
+      # Right now I don't think that is actually a problem.  If you do, you
+      # can go dig out the symlink locations and fake it better. ;)
+      base = Pathname('/sys/class/net') + name
+      base.mkpath               # because we need the directory and parents
+
+      (base + 'type').open('w')    do |fh| fh.puts "1" end
+      (base + 'address').open('w') do |fh| fh.puts address end
     end
   end
 end


### PR DESCRIPTION
This replaces the use of Facter, and regular expressions, in determining the
set of MAC addresses to use for the hardware ID.  Now, instead, we use a
Linux-specific method to get the data -- trolling directly through sysfs and
reading the attributes directly.

Signed-off-by: Daniel Pittman daniel@rimspace.net
