### PR TITLE
Support Secondary Identification of Nodes

### DIFF
--- a/lib/mk/config.rb
+++ b/lib/mk/config.rb
@@ -23,12 +23,33 @@ class MK::Config
   # Error handling and key sanitation is up to the caller.
   def [](key)
     key = key.to_s.downcase
-    get_from_environment(key) or
+    get_from_runtime(key) or
       get_from_kernel_command_line(key) or
       get_from_DHCP_option(key) or
       get_from_config_file(key) or
       get_from_default_config(key) or
       nil
+  end
+
+  def set(key, val)
+    if File.file?(RuntimeConfigurationFile)
+      if File.readable? RuntimeConfigurationFile
+        runtime = JSON.parse(File.read(RuntimeConfigurationFile), 
+          :create_additions => false) rescue {}
+      else
+        #If the file exists, but its not readable, somethings really wrong.
+        return nil
+      end
+    else
+      runtime = {}
+    end
+    
+    key = key.to_s.downcase
+    runtime[key] = val
+
+    fd = File.new(RuntimeConfigurationFile,'w')
+    fd.write(runtime.to_json)
+    fd.close
   end
 
   # Default configuration values
@@ -44,6 +65,13 @@ class MK::Config
   #
   #     {"server": "razor.example.com"}
   ConfigurationFile    = '/etc/razor-mk-client.conf'
+  
+  #Runtime File path.
+  #
+  # This file will preserve runtime configuration between runs.  ENV used
+  # to be good for this, however now that the script runs on a timer
+  # rather than a daemon, ENV is sanitised each run.
+  RuntimeConfigurationFile = '/tmp/razor-mk-runtime.conf'
 
 
   ########################################################################
@@ -56,10 +84,20 @@ class MK::Config
   #
   # This fetches a value of "razor.#{key}" case-insensitively from
   # the environment.
-  def get_from_environment(key)
-    key   = "razor.#{key}"
-    found = ENV.keys.find {|n| key.casecmp(n) == 0 }
-    found and ENV[found]
+  def get_from_runtime(key)
+    # This returns false if the file does not exist.
+    return nil unless File.readable? RuntimeConfigurationFile
+
+    # Parse, but don't use any magic to vivify richer objects than the basic
+    # JSON spec allows -- not date/time magic, or anything else, just Hash,
+    # String, Array, and primitive types.
+    #
+    # In the event of an error, treat the file as empty.
+    data = JSON.parse(File.read(RuntimeConfigurationFile), :create_additions => false) rescue {}
+    return nil unless data.is_a? Hash
+
+    found = data.keys.find {|n| key.casecmp(n) == 0 }
+    found and data[found]
   end
 
   # Fetch a Razor setting from the kernel command line.

--- a/lib/mk/script.rb
+++ b/lib/mk/script.rb
@@ -36,6 +36,10 @@ module MK::Script
     # Dispatch the command we received, unless there is none...
     execute(result['action']) unless result['action'] == 'none'
 
+    if result['id']
+      MK.config.set('id', result['id'])
+    end
+
     # ...and we are good.
     return true
   end

--- a/lib/mk/server.rb
+++ b/lib/mk/server.rb
@@ -12,7 +12,12 @@ class MK::Server
   # Submit a registration request to the server.  This will raise an exception
   # if the request fails.
   def send_register(body, headers)
-    url = URI(MK.config['register'])
+    url = MK.config['register']
+    if MK.config['id']
+      url = url + "/#{MK.config['id']}"
+    end
+    url = URI(url)
+
     raise "HTTPS is not yet supported in #{url}" if url.scheme =~ /\Ahttps\Z/i
     raise "bad URL scheme for #{url}" unless url.scheme =~ /\Ahttp\Z/i
 


### PR DESCRIPTION
Razor will have a second go at identifying an unknown node using the
full compliment of facts available once the MK is loaded.  To support
this the following behaviour changes have been made:
- The node id is now a separate kernel command line option as opposed
  to being part of the register URL.  It is added to the register URL
  when it is available.
- The environment config lookup is no longer valid now that the script
  is executed on a timer as opposed to running as a daemon.  The ENV
  is new and sanitised on each run.  'Runtime' configuration is now
  stored in a file in /tmp as json.  If the ID is learned through a
  checkin, it is stored in here.
- If no ID is appended to the register URL (/svc/checkin), that api
  will return one in its response.  It will be saved for subsequent
  checkins.
