### PR TITLE
(RAZOR-170) Fix dracut could not boot error by patching initrd

### DIFF
--- a/build-livecd-root
+++ b/build-livecd-root
@@ -37,6 +37,38 @@ livecd-creator -v --cache /var/cache/microkernel --config $srcdir/microkernel.ks
 echo "* Converting to initrd"
 livecd-iso-to-pxeboot $tmpdir/microkernel.iso || KEEP_TMPDIR=yes
 
+## Work around dracut not configuring udev correctly for the loopback kernel module
+## See: http://git.kernel.org/cgit/boot/dracut/dracut.git/commit/?id=ba9368fa4fedda0f72d84f910d01d7da201405a3
+mkdir $tmpdir/initrd_root
+# Unpack the first archive, which is the initramfs.  The ISO is second.
+echo "* Unpacking initrd0.img"
+gzip -d -c tftpboot/initrd0.img | (cd $tmpdir/initrd_root; cpio -id)
+# Apply the dracut patch
+echo "* Applying dracut initrd loop patch"
+(cd "$tmpdir"/initrd_root; patch -p0) <<-'DRACUTPATCH'
+--- lib/dracut/hooks/pre-udev/30-dmsquash-liveiso-genrules.sh.bak	2014-03-18 20:16:01.472869714 -0700
++++ lib/dracut/hooks/pre-udev/30-dmsquash-liveiso-genrules.sh	2014-03-18 20:16:49.779746408 -0700
+@@ -4,5 +4,5 @@
+ if [ "${root%%:*}" = "liveiso" ]; then
+     {
+-        printf 'KERNEL=="loop0", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/dmsquash-live-root `/sbin/losetup -f --show %s`"\n' \
++        printf 'KERNEL=="loop-control", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/dmsquash-live-root `/sbin/losetup -f --show %s`"\n' \
+             ${root#liveiso:}
+     } >> /etc/udev/rules.d/99-liveiso-mount.rules
+DRACUTPATCH
+# rebuild the PXE initrd
+echo "* Repacking patched initrd"
+( cd "$tmpdir/initrd_root";
+  find . \
+  | cpio --create --format='newc' \
+  | gzip -c -9 ) \
+    > "$tmpdir"/initrd.gz
+# Append the ISO image to the initrd image.
+echo "* Rebuilding tftpboot/initrd0.img"
+( cd "$tmpdir" && echo "microkernel.iso" | cpio -H newc --quiet -L -o ) |
+  gzip -9 |
+  cat "$tmpdir"/initrd.gz - > tftpboot/initrd0.img
+
 echo "* Building tarball"
 mkdir microkernel
 mv tftpboot/initrd0.img tftpboot/vmlinuz0 microkernel || KEEP_TMPDIR=yes


### PR DESCRIPTION
Without this patch, microkernel images built with this project fail to boot.
The root cause of this problem appears to be an issue with dracut [1](http://git.kernel.org/cgit/boot/dracut/dracut.git/commit/?id=ba9368fa4fedda0f72d84f910d01d7da201405a3) where
dracut mis-configures udev to fire an event when the loop0 device is created.
This is a mis-configuration because loop0 may never be created so the event
never fires.  This, in turn, prevents the root filesystem from being mapped
correctly and an error message `Could not boot` and `/dev/mapper/live-rw does
not exist`.

This patch addresses the problem by patching dracut to monitor the
"loop-control" device, which will be created when the loop kernel module is
loaded.

The patching is done but taking the final initrd0.img, which is in fact two
concatenated gzip compressed cpio archives, unpacking it, patching the initrd
filesystem, then re-packing it.

Unfortunately, this was the best way I could come up with since dracut is
installed by kickstart and we don't really have a great way to inject a patch
without carrying our own version of the package.
