### PR TITLE
Facter 2.0.1 compatibility

### DIFF
--- a/lib/mk/node.rb
+++ b/lib/mk/node.rb
@@ -75,12 +75,13 @@ class MK::Node
   # * Ruby version
   # * Linux kernel version
   def user_agent
+    kernel = Facter[:kernel] ? Facter[:kernel].value : 'unknown'
+    kvers  = Facter[:kernelversion] ? Facter[:kernelversion].value : 'unknown'
     values = {
       'razor'  => MK::VERSION,
       'facter' => Facter.version, # sigh
       'ruby'   => RUBY_VERSION,
-      # @todo danielp 2013-07-30: I can't find a better way to do this...
-      'kernel'  => Facter.kernel + '-' + Facter.kernelversion
+      'kernel' => "#{kernel}-#{kvers}"
     }.reject{|k,v| v.nil?}.map{|k,v| k+'/'+v}.join(' ')
   end
 end


### PR DESCRIPTION
Facter 2.0.1 (and presumably 2.0.0) changed the "API" so that the mechanism
previously used to access the running kernel type and version no longer works.

This updates to use the current "API", which is significantly uglier, but
functions correctly and identically in both releases.

Signed-off-by: Daniel Pittman daniel@rimspace.net
