### PR TITLE
Support external facts

### DIFF
--- a/bin/mk-update
+++ b/bin/mk-update
@@ -41,6 +41,8 @@ if test -d "${livedir}"; then
     export PATH="${livedir}/bin${PATH:+:${PATH}}"
     export LD_LIBRARY_PATH="${livedir}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     export RUBYLIB="${livedir}/lib/ruby${RUBYLIB:+:${RUBYLIB}}"
+    MK_EXTERNAL_FACTS="${livedir}/facts.d"
+    test -d "$MK_EXTERNAL_FACTS" && export MK_EXTERNAL_FACTS
 fi
 
 # Finally, execute the MK client in our new post-update environment.

--- a/lib/mk/node.rb
+++ b/lib/mk/node.rb
@@ -63,8 +63,17 @@ class MK::Node
   # included a selection of hardware based facts.  In this implementation, we
   # simply return what Facter does -- and deploy additional facts of our own
   # as required to add more data.
-  def_delegator 'Facter', 'to_hash', 'facts'
-
+  def facts
+    if ENV['MK_EXTERNAL_FACTS']
+      begin
+        Facter::Util::Config.ext_fact_loader = Facter::Util::DirectoryLoader.loader_for(ENV['MK_EXTERNAL_FACTS'])
+      rescue Facter::Util::DirectoryLoader::NoSuchDirectoryError
+        # An error here should go back to the server; though how ?
+        # But carry on anyway
+      end
+    end
+    Facter::to_hash
+  end
 
   # Calculate the "user agent" string, which is a collection of versioning
   # information potentially useful to supply to the server.


### PR DESCRIPTION
When a downloaded extension file contains a facts.d/ directory, use that es
the external facts directory for facter.
