### PR TITLE
Remove python pyc files

### DIFF
--- a/microkernel.ks
+++ b/microkernel.ks
@@ -152,6 +152,9 @@ echo " * disable sshd and purge existing SSH host keys"
 rm -f /etc/ssh/ssh_host_*key{,.pub}
 systemctl disable sshd.service
 
+echo " * removing python precompiled *.pyc files"
+find /usr/lib64/python*/ -name *pyc -print0 | xargs -0 rm -f
+
 # This seems to cause 'reboot' resulting in a shutdown on certain platforms
 # See https://tickets.puppetlabs.com/browse/RAZOR-100
 echo " * disable the mei_me module"


### PR DESCRIPTION
This patch removes Python PYC compiled code from the Python core library. 
Since PYO optimized/compiled files are present, these are not necessary. It 
saves about 4 MB on the image.
