### PR TITLE
build toolchain fails without tar

### DIFF
--- a/microkernel.ks
+++ b/microkernel.ks
@@ -44,6 +44,7 @@ rootfiles
 yum
 vim-minimal
 acpid
+tar
 # RAZOR-145 Add dmidecode for facter support
 dmidecode
 # Additional dependency for facter support
@@ -95,7 +96,6 @@ net-tools
 -prelink
 -setserial
 -ed
--tar
 
 # Remove the authconfig pieces
 -authconfig


### PR DESCRIPTION
The livecd-tools fail without tar explicitly defined. More information in [RAZOR-855](https://tickets.puppetlabs.com/browse/RAZOR-855)