### PR TITLE
Remove dracut code completely

### DIFF
--- a/build-livecd-root
+++ b/build-livecd-root
@@ -37,25 +37,6 @@ livecd-creator -v --cache /var/cache/microkernel --config $srcdir/microkernel.ks
 echo "* Converting to initrd"
 livecd-iso-to-pxeboot $tmpdir/microkernel.iso || KEEP_TMPDIR=yes
 
-## Work around dracut not configuring udev correctly for the loopback kernel module
-## See: http://git.kernel.org/cgit/boot/dracut/dracut.git/commit/?id=ba9368fa4fedda0f72d84f910d01d7da201405a3
-mkdir $tmpdir/initrd_root
-# Unpack the first archive, which is the initramfs.  The ISO is second.
-echo "* Unpacking initrd0.img"
-gzip -d -c tftpboot/initrd0.img | (cd $tmpdir/initrd_root; cpio -id)
-# rebuild the PXE initrd
-echo "* Repacking patched initrd"
-( cd "$tmpdir/initrd_root";
-  find . \
-  | cpio --create --format='newc' \
-  | gzip -c -9 ) \
-    > "$tmpdir"/initrd.gz
-# Append the ISO image to the initrd image.
-echo "* Rebuilding tftpboot/initrd0.img"
-( cd "$tmpdir" && echo "microkernel.iso" | cpio -H newc --quiet -L -o ) |
-  gzip -9 |
-  cat "$tmpdir"/initrd.gz - > tftpboot/initrd0.img
-
 echo "* Building tarball"
 mkdir microkernel
 mv tftpboot/initrd0.img tftpboot/vmlinuz0 microkernel || KEEP_TMPDIR=yes


### PR DESCRIPTION
In https://github.com/johnf/razor-el-mk/commit/c21851f0cdc721f2da107b5330b87f11e1ee0743 some code was added to patch the initrd.

In https://github.com/johnf/razor-el-mk/commit/8968ddef362fc0a4578c51e6e6869b1ad2a1a3b4 this was only partially removed.

The code left around fails at the moment since the init.rd generated is no longer gziped.

I've removed all the excess code