### PR TITLE
Configure journald

### DIFF
--- a/microkernel.ks
+++ b/microkernel.ks
@@ -164,6 +164,12 @@ EOMEI
 echo " * compressing cracklib dictionary"
 gzip -9 /usr/share/cracklib/pw_dict.pwd
 
+echo " * setting up journald and tty2"
+echo "SystemMaxUse=15M" >> /etc/systemd/journald.conf
+echo "ForwardToSyslog=no" >> /etc/systemd/journald.conf
+echo "ForwardToConsole=yes" >> /etc/systemd/journald.conf
+echo "TTYPath=/dev/tty2" >> /etc/systemd/journald.conf
+
 # 100MB of locale archive is kind unnecessary; we only do en_US.utf8
 # this will clear out everything we don't need; 100MB => 2.1MB.
 echo " * minimizing locale-archive binary / memory size"


### PR DESCRIPTION
Since microkernel runs from memory, journal can reach the limits. This patch
adds 15 MB limit which forces journald to rotate logs.

This patch also configures journald to write the log to tty2.

NOTE: This is adapted from original work by lzap: https://github.com/puppetlabs/razor-el-mk/pull/24