### PR TITLE
(maint) Add script for building microkernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ inventory of new machines.
 This section describes how to build an image on a
 [CentOS](http://centos.org/) system.
 
+## Automated script
+
+A script for building the microkernel on a vanilla build of CentOS exists
+in the `bin/` directory, and is linked via [short link](http://pup.pt/build-razor-microkernel).
+Run the script in a vanilla CentOS build with the following command:
+
+`curl -L pup.pt/build-razor-microkernel | sudo bash`
+
+Optionally, if the ruby version has changed from the version specified in the
+Gemfile, this can be specified as a parameter in the script:
+
+`curl -L pup.pt/build-razor-microkernel | sudo bash -s 2.7.0`
+
+## Process explanation
+
 First, install the necessary system dependencies.  The system itself has been
 installed from the network infrastructure server role, with the compilers,
 rpmbuild tools, and system tools group selected.

--- a/bin/build-mk
+++ b/bin/build-mk
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+set -x
+ruby=${1:-2.6.2}
+yum -y install livecd-tools git
+
+# install build dependencies
+sudo yum install -y git-core zlib zlib-devel gcc-c++ patch readline readline-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison curl sqlite-devel
+
+# clone and install rbenv environment
+cd ~
+[ -e ~/.rbenv ] || git clone git://github.com/sstephenson/rbenv.git ~/.rbenv
+[ -e ~/.rbenv/plugins/ruby-build ] || git clone git://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
+echo 'export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bash_profile
+echo 'eval "$(~/.rbenv/bin/rbenv init -)"' >> ~/.bash_profile
+
+# re-init bash
+source ~/.bash_profile
+
+# install latest ruby
+~/.rbenv/bin/rbenv versions | grep -q $ruby || ~/.rbenv/bin/rbenv install -v $ruby
+
+# sets the default ruby version that the shell will use
+~/.rbenv/bin/rbenv global $ruby
+
+# to disable generating of documents as that would take so much time
+echo "gem: --no-document" > .gemrc
+
+# install bundler
+gem install bundler
+
+# must be executed everytime a gem has been installed in order for the ruby executable to run
+~/.rbenv/bin/rbenv rehash
+
+gem update --system && gem install rake bundler
+setenforce 0
+cd ~
+rm -rf razor-el-mk
+git clone https://github.com/puppetlabs/razor-el-mk
+cd razor-el-mk
+sed -i'' -e "s/ruby\ '.*'/ruby\ '$ruby'/" Gemfile
+bundle install --path .bundle/gems/
+bundle exec rake build
+./build-livecd
+sudo ./build-livecd-root
+# Move the microkernel to the home directory.
+mv ./pkg/microkernel* ~


### PR DESCRIPTION
This adds a script for building the microkernel on CentOS, simplifying the process for generating
a microkernel on a vanilla CentOS build.