### PR TITLE
adding the changes which fixes the dhcp issue in microkernel

### DIFF
--- a/microkernel.ks
+++ b/microkernel.ks
@@ -19,7 +19,7 @@ rootpw --iscrypted $1$uw6MV$m6VtUWPed4SqgoW6fKfTZ/
 # This information is used by appliance-tools but
 # not by the livecd tools.
 #
-part / --size 1024 --fstype ext4 --ondisk sda
+part / --size 4096 --fstype ext4 --ondisk sda
 
 #
 # Repositories
@@ -89,7 +89,9 @@ binutils
 rubygems
 facter
 net-tools
-
+dhcp-libs
+dhcp-common
+dhclient
 #
 # Packages to Remove
 #


### PR DESCRIPTION
1. For compilation and creation of microkernel image modified below line by replacing the size of the sector to 4096 : 
part / --size 4096 --fstype ext4 --ondisk sda

2. For fixing the dhcp mac issue in the microkernel Added the below installables in the microkernel
dhcp-libs
dhcp-common
dhclient